### PR TITLE
Fix lifetime issue + fixes to the design

### DIFF
--- a/src/audit_file.rs
+++ b/src/audit_file.rs
@@ -441,7 +441,7 @@ impl AuditFile {
     pub fn new_caller_checked_default_with_results(
         crate_path: &FilePath,
         relevant_effects: &[EffectType],
-        quick: &bool,
+        quick: bool,
     ) -> Result<(AuditFile, ScanResults)> {
         Self::new_caller_checked_default_with_sinks_and_results(
             crate_path,
@@ -460,7 +460,7 @@ impl AuditFile {
             crate_path,
             sinks,
             relevant_effects,
-            &false,
+            false,
         )
         .map(|x| x.0)
     }
@@ -469,14 +469,14 @@ impl AuditFile {
         crate_path: &FilePath,
         sinks: HashSet<CanonicalPath>,
         relevant_effects: &[EffectType],
-        quick: &bool,
+        quick: bool,
     ) -> Result<(AuditFile, ScanResults)> {
         let mut audit_file =
             AuditFile::empty(crate_path.to_path_buf(), relevant_effects.to_vec())?;
         let ident_sinks =
             sinks.iter().map(|x| x.clone().to_path()).collect::<HashSet<_>>();
         let scan_res =
-            scanner::scan_crate_with_sinks(crate_path, ident_sinks, relevant_effects , quick)?;
+            scanner::scan_crate_with_sinks(crate_path, ident_sinks, relevant_effects, quick)?;
         let mut pub_caller_checked = HashMap::new();
         audit_file.set_base_audit_trees(scan_res.effects_set());
 
@@ -499,7 +499,7 @@ impl AuditFile {
         let ident_sinks =
             sinks.iter().map(|x| x.clone().to_path()).collect::<HashSet<_>>();
         let scan_res =
-            scanner::scan_crate_with_sinks(crate_path, ident_sinks, relevant_effects , &false)?;
+            scanner::scan_crate_with_sinks(crate_path, ident_sinks, relevant_effects, false)?;
         audit_file.set_base_audit_trees(scan_res.effects_set());
 
         Ok(audit_file)

--- a/src/bin/scan.rs
+++ b/src/bin/scan.rs
@@ -48,7 +48,7 @@ fn main() -> Result<()> {
     let (audit, results) = AuditFile::new_caller_checked_default_with_results(
         &args.crate_path,
         &args.effect_types,
-        &args.quick_mode
+        args.quick_mode
     )?;
 
     // Note: old version without default_audit:

--- a/src/hacky_resolver.rs
+++ b/src/hacky_resolver.rs
@@ -191,12 +191,12 @@ impl<'a> Resolve<'a> for HackyResolver<'a> {
         CanonicalPath::new_owned(format!("UNKNOWN_METHOD::{}", i), src_loc)
     }
 
-    fn resolve_field(&self, i: &'a syn::Ident) -> CanonicalPath {
+    fn resolve_field(&self, i: &syn::Ident) -> CanonicalPath {
         let src_loc = SrcLoc::from_span(self.filepath, &i.span());
         CanonicalPath::new_owned(format!("UNKNOWN_FIELD::{}", i), src_loc)
     }
 
-    fn resolve_field_type(&self, i: &'a syn::Ident) -> CanonicalType {
+    fn resolve_field_type(&self, i: &syn::Ident) -> CanonicalType {
         CanonicalType::new_owned_string(format!("UNKNOWN_TYPE::{}", i))
     }
 

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -51,7 +51,7 @@ pub trait Resolve<'a>: Sized {
     /*
         Field and expression resolution
     */
-    fn resolve_field(&self, i: &'a syn::Ident) -> CanonicalPath;
+    fn resolve_field(&self, i: &syn::Ident) -> CanonicalPath;
     fn resolve_field_index(&self, idx: &'a syn::Index) -> CanonicalPath;
     fn resolve_closure(&self, cl: &'a syn::ExprClosure) -> CanonicalPath;
     fn resolve_const_or_static(&self, p: &'a syn::Path) -> bool;
@@ -60,7 +60,7 @@ pub trait Resolve<'a>: Sized {
         Type resolution
     */
     fn resolve_path_type(&self, i: &'a syn::Path) -> CanonicalType;
-    fn resolve_field_type(&self, i: &'a syn::Ident) -> CanonicalType;
+    fn resolve_field_type(&self, i: &syn::Ident) -> CanonicalType;
 
     /*
         Optional helper functions to inform the resolver of the scope
@@ -274,7 +274,7 @@ impl<'a> Resolve<'a> for FileResolver<'a> {
         self.resolve_ident_or_else(i, || self.backup.resolve_method(i))
     }
 
-    fn resolve_field(&self, i: &'a syn::Ident) -> CanonicalPath {
+    fn resolve_field(&self, i: &syn::Ident) -> CanonicalPath {
         self.resolve_ident_or_else(i, || self.backup.resolve_field(i))
     }
 
@@ -287,7 +287,7 @@ impl<'a> Resolve<'a> for FileResolver<'a> {
         self.backup.resolve_field_index(idx)
     }
 
-    fn resolve_field_type(&self, i: &'a syn::Ident) -> CanonicalType {
+    fn resolve_field_type(&self, i: &syn::Ident) -> CanonicalType {
         self.resolve_type_or_else(i, || self.backup.resolve_field_type(i))
     }
 

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -115,194 +115,15 @@ impl ScanResults {
 }
 
 #[derive(Debug)]
-enum MultiResolver<'a> {
-    File(FileResolver<'a>),
-    Hacky(HackyResolver<'a>),
-}
-
-/// Stateful object to scan Rust source code for effects (fn calls of interest)
-
-impl MultiResolver<'_> {
-    fn push_mod(&mut self, ident: &syn::Ident) {
-        match self {
-            MultiResolver::File(file_resolver) => {
-                file_resolver.push_mod(ident);
-            }
-            MultiResolver::Hacky(hacky_resolver) => {
-                hacky_resolver.push_mod(ident);
-            }
-        }
-    }
-
-    fn pop_mod(&mut self) {
-        match self {
-            MultiResolver::File(file_resolver) => {
-                file_resolver.pop_mod();
-            }
-            MultiResolver::Hacky(hacky_resolver) => {
-                hacky_resolver.pop_mod();
-            }
-        }
-    }
-
-    fn push_fn(&mut self, ident: &syn::Ident) {
-        match self {
-            MultiResolver::File(file_resolver) => {
-                file_resolver.push_fn(ident);
-            }
-            MultiResolver::Hacky(hacky_resolver) => {
-                hacky_resolver.push_fn(ident);
-            }
-        }
-    }
-
-    fn pop_fn(&mut self) {
-        match self {
-            MultiResolver::File(file_resolver) => {
-                file_resolver.pop_fn();
-            }
-            MultiResolver::Hacky(hacky_resolver) => {
-                hacky_resolver.pop_fn();
-            }
-        }
-    }
-
-    fn resolve_path(&self, path: &syn::Path) -> CanonicalPath {
-        match self {
-            MultiResolver::File(file_resolver) => {
-                file_resolver.resolve_path(path)
-            }
-            MultiResolver::Hacky(hacky_resolver) => {
-                hacky_resolver.resolve_path(path)
-            }
-        }
-    }
-
-    fn resolve_field(&self, ident: &syn::Ident) -> CanonicalPath {
-        match self {
-            MultiResolver::File(file_resolver) => {
-                file_resolver.resolve_field(ident)
-            }
-            MultiResolver::Hacky(hacky_resolver) => {
-                hacky_resolver.resolve_field(ident)
-            }
-        }
-    }
-
-    fn resolve_closure(&self, closure: &syn::ExprClosure) -> CanonicalPath {
-        match self {
-            MultiResolver::File(resolver) => resolver.resolve_closure(closure),
-            MultiResolver::Hacky(resolver) => resolver.resolve_closure(closure),
-        }
-    }
-
-    fn resolve_field_type(&self, ident: &syn::Ident) -> CanonicalType {
-        match self {
-            MultiResolver::File(resolver) => resolver.resolve_field_type(ident),
-            MultiResolver::Hacky(resolver) => resolver.resolve_field_type(ident),
-        }
-    }
-    
-    fn resolve_path_type(&self, path: &syn::Path) -> CanonicalType {
-        match self {
-            MultiResolver::File(resolver) => resolver.resolve_path_type(path),
-            MultiResolver::Hacky(resolver) => resolver.resolve_path_type(path),
-        }
-    }
-
-    fn resolve_const_or_static(&self, path: &syn::Path) -> bool {
-        match self {
-            MultiResolver::File(resolver) => resolver.resolve_const_or_static(path),
-            MultiResolver::Hacky(resolver) => resolver.resolve_const_or_static(path),
-        }
-    }
-
-    fn resolve_ffi(&self, path: &syn::Path) -> Option<CanonicalPath> {
-        match self {
-            MultiResolver::File(resolver) => resolver.resolve_ffi(path),
-            MultiResolver::Hacky(resolver) => resolver.resolve_ffi(path),
-        }
-    }
-
-    fn resolve_unsafe_ident(&self, ident: &syn::Ident) -> bool {
-        match self {
-            MultiResolver::File(resolver) => resolver.resolve_unsafe_ident(ident),
-            MultiResolver::Hacky(resolver) => resolver.resolve_unsafe_ident(ident),
-        }
-    }
-
-    fn resolve_field_index(&self, index: &syn::Index) -> CanonicalPath {
-        match self {
-            MultiResolver::File(resolver) => resolver.resolve_field_index(index),
-            MultiResolver::Hacky(resolver) => resolver.resolve_field_index(index),
-        }
-    }
-
-    fn resolve_unsafe_path(&self, path: &syn::Path) -> bool {
-        match self {
-            MultiResolver::File(resolver) => resolver.resolve_unsafe_path(path),
-            MultiResolver::Hacky(resolver) => resolver.resolve_unsafe_path(path),
-        }
-    }
-
-    fn resolve_method(&self, ident: &syn::Ident) -> CanonicalPath {
-        match self {
-            MultiResolver::File(resolver) => resolver.resolve_method(ident),
-            MultiResolver::Hacky(resolver) => resolver.resolve_method(ident),
-        }
-    }
-
-    fn resolve_def(&self, ident: &syn::Ident) -> CanonicalPath {
-        match self {
-            MultiResolver::File(file_resolver) => file_resolver.resolve_def(ident),
-            MultiResolver::Hacky(hacky_resolver) => hacky_resolver.resolve_def(ident),
-        }
-    }
-
-    fn push_impl(&mut self, imp: &syn::ItemImpl) {
-        match self {
-            MultiResolver::File(file_resolver) => file_resolver.push_impl(imp),
-            MultiResolver::Hacky(hacky_resolver) => hacky_resolver.push_impl(imp),
-        }
-    }
-
-    fn pop_impl(&mut self) {
-        match self {
-            MultiResolver::File(file_resolver) => file_resolver.pop_impl(),
-            MultiResolver::Hacky(hacky_resolver) => hacky_resolver.pop_impl(),
-        }
-    }
-
-    fn resolve_all_impl_methods(&self, trait_ident: &syn::Ident, method_name: String) -> Vec<CanonicalPath> {
-        match self {
-            MultiResolver::File(file_resolver) => file_resolver.resolve_all_impl_methods(trait_ident, method_name),
-            MultiResolver::Hacky(hacky_resolver) => hacky_resolver.resolve_all_impl_methods(trait_ident, method_name),
-        }
-    }
-
-    fn scan_foreign_fn(&mut self, f: &syn::ForeignItemFn) {
-        match self {
-            MultiResolver::File(file_resolver) => file_resolver.scan_foreign_fn(f),
-            MultiResolver::Hacky(hacky_resolver) => hacky_resolver.scan_foreign_fn(f),
-        }
-    }
-
-    fn scan_use(&mut self, use_item: &syn::ItemUse) {
-        match self {
-            MultiResolver::File(file_resolver) => file_resolver.scan_use(use_item),
-            MultiResolver::Hacky(hacky_resolver) => hacky_resolver.scan_use(use_item),
-        }
-    }
-}
-
-#[derive(Debug)]
-pub struct Scanner<'a> {
+pub struct Scanner<'a, R>
+where
+    R: Resolve<'a>,
+{
     /// filepath that the scanner is being run on
     filepath: &'a FilePath,
 
     /// Name resolution resolver
-    resolver: MultiResolver<'a>,
-    // hacky_resolver : HackyResolver<'a>,
+    resolver: R,
 
     /// Number of unsafe keywords the current scope is nested inside
     /// (always 0 at top level)
@@ -332,7 +153,10 @@ pub struct Scanner<'a> {
     enabled_cfg: &'a HashMap<String, Vec<String>>,
 }
 
-impl<'a> Scanner<'a> {
+impl<'a, R> Scanner<'a, R>
+where
+    R: Resolve<'a>,
+{
     /*
         Main public API
     */
@@ -340,7 +164,7 @@ impl<'a> Scanner<'a> {
     /// Create a new scanner tied to a crate and file
     pub fn new(
         filepath: &'a FilePath,
-        resolver: MultiResolver<'a>,
+        resolver: R,
         data: &'a mut ScanResults,
         enabled_cfg: &'a HashMap<String, Vec<String>>,
     ) -> Self {
@@ -361,15 +185,7 @@ impl<'a> Scanner<'a> {
 
     /// Top-level invariant -- called before consuming results
     pub fn assert_top_level_invariant(&self) {
-        match &self.resolver {
-            MultiResolver::File(file_resolver) => {
-                file_resolver.assert_top_level_invariant();
-            }
-            MultiResolver::Hacky(hacky_resolver) => {
-                hacky_resolver.assert_top_level_invariant();
-            }
-        }
-        // self.resolver.assert_top_level_invariant();
+        self.resolver.assert_top_level_invariant();
         debug_assert!(self.scope_fns.is_empty());
         debug_assert_eq!(self.scope_unsafe, 0);
         debug_assert_eq!(self.scope_unsafe_effects, 0);
@@ -465,27 +281,13 @@ impl<'a> Scanner<'a> {
             self.data.skipped_conditional_code.add(m);
             return;
         }
-    
+
         if let Some((_, items)) = &m.content {
-            match &mut self.resolver {
-                MultiResolver::File(file_resolver) => {
-                    file_resolver.push_mod(&m.ident);
-                }
-                MultiResolver::Hacky(hacky_resolver) => {
-                    hacky_resolver.push_mod(&m.ident);
-                }
-            }
+            self.resolver.push_mod(&m.ident);
             for i in items {
                 self.scan_item(i);
             }
-            match &mut self.resolver {
-                MultiResolver::File(file_resolver) => {
-                    file_resolver.pop_mod();
-                }
-                MultiResolver::Hacky(hacky_resolver) => {
-                    hacky_resolver.pop_mod();
-                }
-            }
+            self.resolver.pop_mod();
         }
     }
 
@@ -1182,7 +984,7 @@ impl<'a> Scanner<'a> {
             }
         }
     }
-        
+
     fn scan_expr_call_field(&mut self, m: &'a syn::Member) {
         match m {
             syn::Member::Named(i) => {
@@ -1207,6 +1009,18 @@ impl<'a> Scanner<'a> {
     }
 }
 
+/// Load the Rust file at the filepath and scan it (quick mode)
+pub fn scan_file_quick(
+    crate_name: &str,
+    filepath: &FilePath,
+    scan_results: &mut ScanResults,
+    sinks: HashSet<IdentPath>,
+    enabled_cfg: &HashMap<String, Vec<String>>,
+) -> Result<()> {
+    // TODO
+    todo!()
+}
+
 /// Load the Rust file at the filepath and scan it
 pub fn scan_file(
     crate_name: &str,
@@ -1215,7 +1029,6 @@ pub fn scan_file(
     scan_results: &mut ScanResults,
     sinks: HashSet<IdentPath>,
     enabled_cfg: &HashMap<String, Vec<String>>,
-    quick_mode: &bool
 ) -> Result<()> {
     info!("Scanning file: {:?}", filepath);
 
@@ -1225,19 +1038,14 @@ pub fn scan_file(
     file.read_to_string(&mut src)?;
     let syntax_tree = syn::parse_file(&src)?;
 
-    // Initialize data structures
-    let file_resolver = FileResolver::new(crate_name, resolver, filepath)?;
+    // Initialize resolver data structures
     let hacky_resolver = HackyResolver::new(crate_name, filepath);
-    
-    let resolver = if *quick_mode {
-        MultiResolver::Hacky(HackyResolver::new(crate_name, filepath)?)
-    } else {
-        MultiResolver::File(FileResolver::new(crate_name, resolver, filepath)?)
-    };
-    
-    let mut scanner = Scanner::new(filepath, resolver, scan_results, enabled_cfg);
 
-    // let mut scanner = Scanner::new(filepath, file_resolver, scan_results, enabled_cfg);
+    // Initialize resolver
+    let file_resolver = FileResolver::new(crate_name, resolver, filepath)?;
+
+    // Initialize scanner
+    let mut scanner = Scanner::new(filepath, file_resolver, scan_results, enabled_cfg);
     scanner.add_sinks(sinks);
 
     // Scan file contents
@@ -1254,9 +1062,9 @@ pub fn try_scan_file(
     scan_results: &mut ScanResults,
     sinks: HashSet<IdentPath>,
     enabled_cfg: &HashMap<String, Vec<String>>,
-    quick_mode: &bool
+    quick_mode: bool,
 ) {
-    scan_file(crate_name, filepath, resolver, scan_results, sinks, enabled_cfg , quick_mode)
+    scan_file(crate_name, filepath, resolver, scan_results, sinks, enabled_cfg)
         .unwrap_or_else(|err| {
             warn!("Failed to scan file: {} ({})", filepath.to_string_lossy(), err);
         });
@@ -1267,7 +1075,7 @@ pub fn scan_crate_with_sinks(
     crate_path: &FilePath,
     sinks: HashSet<IdentPath>,
     relevant_effects: &[EffectType],
-    quick_mode: &bool,
+    quick_mode: bool,
 ) -> Result<ScanResults> {
     info!("Scanning crate: {:?}", crate_path);
 
@@ -1284,6 +1092,7 @@ pub fn scan_crate_with_sinks(
 
     let crate_name = util::load_cargo_toml(crate_path)?.crate_name;
 
+    // TODO: this should *not* be created in the quick-mode case
     let resolver = Resolver::new(crate_path)?;
 
     let mut scan_results = ScanResults::new();
@@ -1339,5 +1148,5 @@ pub fn scan_crate(
     crate_path: &FilePath,
     relevant_effects: &[EffectType],
 ) -> Result<ScanResults> {
-    scan_crate_with_sinks(crate_path, HashSet::new(), relevant_effects , &false)
+    scan_crate_with_sinks(crate_path, HashSet::new(), relevant_effects, false)
 }


### PR DESCRIPTION
Here is a pull request with suggested changes!

The lifetime issue was related to some annotations in the `Resolver` trait, where the annotations were overly restrictive in some cases, which I have now fixed.

In addition to this, I've fixed the design -- you had added a MultiResolver struct, but this requires lots of overhead matching on which resolver is used. The design I had in mind is a bit cleaner, we just make the resolver a type parameter as shown in the pull request, then you can omit MultiResolver entirely :)

Finally, a minor thing, when passing small types like `bool` and integer types as arguments, it usually makes sense to pass them by value instead of by reference (i.e. `quick: bool` instead of `quick: &bool`). These are called `Copy` types meaning that they are automatically copied on each function call.
